### PR TITLE
feat: add transform config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,10 +97,11 @@ config options:
     the current stream. After writing, the stream is ended
   - `StreamChopper.underflow` - End the current output stream and write
     the entire chunk to the next stream
-- `compressor` - An optional function that returns a zlib compressor
-  object to use for compressing the data. If used, the `size` option
-  will count towards the compressed payload. This config option cannot
-  be used together with the `StreamChopper.split` type
+- `transform` - An optional function that returns a transform stream
+  used for transforming the data in some way (e.g. a zlib Gzip stream).
+  If used, the `size` option will count towards the size of the output
+  chunks. This config option cannot be used together with the
+  `StreamChopper.split` type
 
 If `type` is `StreamChopper.underflow` and the size of the chunk to be
 written is larger than `size` an error is emitted.

--- a/README.md
+++ b/README.md
@@ -97,6 +97,10 @@ config options:
     the current stream. After writing, the stream is ended
   - `StreamChopper.underflow` - End the current output stream and write
     the entire chunk to the next stream
+- `compressor` - An optional function that returns a zlib compressor
+  object to use for compressing the data. If used, the `size` option
+  will count towards the compressed payload. This config option cannot
+  be used together with the `StreamChopper.split` type
 
 If `type` is `StreamChopper.underflow` and the size of the chunk to be
 written is larger than `size` an error is emitted.

--- a/index.js
+++ b/index.js
@@ -128,9 +128,7 @@ StreamChopper.prototype._maybeEndTransformSteam = function () {
 
   // in case of backpresure on the transform stream, count how many bytes are
   // buffered
-  const bufferedSize = this._stream.writableBuffer.reduce((total, b) => {
-    return total + b.chunk.length
-  }, 0)
+  const bufferedSize = getBufferedSize(this._stream)
 
   const overflow = (this._bytes + bufferedSize) - this.size
 
@@ -281,3 +279,10 @@ StreamChopper.prototype._final = function (cb) {
 }
 
 function noop () {}
+
+function getBufferedSize (stream) {
+  const buffer = stream.writableBuffer || stream._writableState.getBuffer()
+  return buffer.reduce((total, b) => {
+    return total + b.chunk.length
+  }, 0)
+}

--- a/test.js
+++ b/test.js
@@ -87,7 +87,7 @@ test('transform: very fast writes should not exceed size limit too much', functi
     type: StreamChopper.overflow,
     transform: function () {
       return zlib.createGzip({
-        level: zlib.constants.Z_NO_COMPRESSION
+        level: zlib.constants ? zlib.constants.Z_NO_COMPRESSION : zlib.Z_NO_COMPRESSION
       })
     }
   })

--- a/test.js
+++ b/test.js
@@ -17,7 +17,7 @@ test('default values', function (t) {
   t.equal(chopper.size, Infinity)
   t.equal(chopper.time, -1)
   t.equal(chopper.type, StreamChopper.split)
-  t.equal(chopper._compressor, undefined)
+  t.equal(chopper._transform, undefined)
   t.equal(chopper._locked, false)
   t.equal(chopper._draining, false)
   t.equal(chopper._destroyed, false)
@@ -28,12 +28,12 @@ test('throw on invalid config', function (t) {
   t.throws(function () {
     new StreamChopper({ // eslint-disable-line no-new
       type: StreamChopper.split,
-      compressor: function () {}
+      transform: function () {}
     })
   })
   t.throws(function () {
     new StreamChopper({ // eslint-disable-line no-new
-      compressor: function () {}
+      transform: function () {}
     })
   })
   t.end()
@@ -60,7 +60,7 @@ types.forEach(function (type) {
   })
 })
 
-test('very fast writes should not exceed size limit too much', function (t) {
+test('transform: very fast writes should not exceed size limit too much', function (t) {
   const writes = [
     crypto.randomBytes(5 * 1024).toString('hex'),
     crypto.randomBytes(5 * 1024).toString('hex'),
@@ -85,7 +85,7 @@ test('very fast writes should not exceed size limit too much', function (t) {
   const chopper = new StreamChopper({
     size,
     type: StreamChopper.overflow,
-    compressor: function () {
+    transform: function () {
       return zlib.createGzip({
         level: zlib.constants.Z_NO_COMPRESSION
       })


### PR DESCRIPTION
This PR allows users to pass in a transform stream (e.g. a zlib Gzip stream) to be used instead of the `PassThrough` stream that was always used before as the output stream. When doing so, the size of the transformed chunks will be used to calculate the size when determining when to chop.

It was pretty much impossible to achieve the same effect outside the module before because of all the internal buffering caused by the `PassThrough` stream. By allowing the user to use another stream instead of the `PassThrough` we eliminate this problem.

I've called the config option `transform` as it can be any type of transform stream. But in most cases it will probably be a compression stream.